### PR TITLE
Hide QA users

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,8 @@
   <url>http://maven.apache.org</url>
 
   <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -31,6 +33,16 @@
       <artifactId>json</artifactId>
       <version>20160810</version>
     </dependency>
-    
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>10.0.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.13</version>
+    </dependency>
+
   </dependencies>
 </project>

--- a/src/main/java/com/faceyspacies/TyRC/Listeners/FreenodeListener.java
+++ b/src/main/java/com/faceyspacies/TyRC/Listeners/FreenodeListener.java
@@ -24,7 +24,7 @@ public class FreenodeListener extends ListenerAdapter {
 
   @Override
   public void onJoin(JoinEvent e) {
-    if (e.getUserHostmask().getHostname().equals("wikia/TyBot")) {
+    if (e.getUserHostmask().getHostname().equals(main.getHostmask())) {
       main.setIsReady(true);
     }
   }

--- a/src/main/java/com/faceyspacies/TyRC/Listeners/WikiaRCListener.java
+++ b/src/main/java/com/faceyspacies/TyRC/Listeners/WikiaRCListener.java
@@ -28,6 +28,10 @@ public class WikiaRCListener extends ListenerAdapter {
     try {
       DiscussionsFeedEntry in = new DiscussionsFeedEntry(e.getMessage());
 
+      if (shouldIgnoreUser(in.getUser())) {
+        return;
+      }
+
       StringBuilder out = new StringBuilder(Colors.DARK_GREEN + "[[User:");
       out.append(in.getUser()).append("]]" + Colors.NORMAL);
 
@@ -124,5 +128,10 @@ public class WikiaRCListener extends ListenerAdapter {
       e1.printStackTrace();
     }
 
+  }
+
+  private boolean shouldIgnoreUser(String user) {
+    return user.startsWith("QATestsUser") ||
+           user.startsWith("QATestsStaff");
   }
 }

--- a/src/main/java/com/faceyspacies/TyRC/TyRC.java
+++ b/src/main/java/com/faceyspacies/TyRC/TyRC.java
@@ -47,8 +47,8 @@ public class TyRC {
             .setName(config.getProperty("reportnick", "TyRC"))
             .setAutoNickChange(true)
             .setAutoReconnect(true)
-            .setLogin("tybot")
-            .setRealName("TyRC")
+            .setLogin(config.getProperty("reportusername", "tybot"))
+            .setRealName(config.getProperty("realname", "TyRC"))
             .addAutoJoinChannel(config.getProperty("reportchannel", "#tybot"))
             .addListener(new FreenodeListener(manager, this))
             .addServer("irc.freenode.net")
@@ -58,12 +58,11 @@ public class TyRC {
 
     Configuration wikiaConfig =
         new Configuration.Builder()
-            .setName("TyRC")
+            .setName(config.getProperty("feednick", "TyRC"))
             .setAutoNickChange(true)
             .setAutoReconnect(true)
-            .setLogin("tybot")
-            .setRealName("TyRC")
-            .setName("TyRC")
+            .setLogin(config.getProperty("reportusername", "tybot"))
+            .setRealName(config.getProperty("realname", "TyRC"))
             .addListener(new WikiaRCListener(manager, this))
             .addAutoJoinChannel("#discussionsfeed")
             .addServer(config.getProperty("feednetwork", null),
@@ -121,5 +120,9 @@ public class TyRC {
 
   public String getReportChannel() {
     return config.getProperty("reportchannel");
+  }
+
+  public String getHostmask() {
+    return config.getProperty("hostmask", "wikia/TyBot");
   }
 }

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,9 @@
+# Root logger option
+log4j.rootLogger=INFO, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+

--- a/tyrc.properties.sample
+++ b/tyrc.properties.sample
@@ -4,3 +4,6 @@ reportnick=TyRC
 reportpassword=
 feednetwork=
 feedport=
+feednick=TyRC
+hostmask=wikia/TyBot
+realname=TyRC


### PR DESCRIPTION
Changes include:
- Adding missing dependencies in `pom.xml`
- Allowing a configurable hostmask, nickname in WikiaRC and realname
- Setting up a logger (if this logs too much, might want to consider switching it for `slf4j-nop`)
- Ignoring Discussions posts by users whose usernames start with `QATestsUser` or `QATestsStaff` (resolves #11)